### PR TITLE
Add param to enable board conclusion in job post

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -28,6 +28,7 @@ async function getJobsForDepartment(apiToken, departmentId) {
 async function getJobPosts(apiToken, queryParams) {
   return axios.get('https://harvest.greenhouse.io/v1/job_posts', {
     params: {
+      full_content: true,
       live: true,
       per_page: 500
     },


### PR DESCRIPTION
Hey Ivan,

The people team have begun using a new feature in Greenhouse that allows them to set up part of the job description as a global text, which is a field called _Conclusion_, that gets added ad the bottom of the job post:
https://support.greenhouse.io/hc/en-us/articles/360048989471-Standardized-post-descriptions

A change in the API request is needed to get this field as part of the regular content:
https://support.greenhouse.io/hc/en-us/articles/360048989471-Standardized-post-descriptions#h_01EH5GA7BDB4MY1PZ9VCVBJT65